### PR TITLE
Adding Mastodon account to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,6 +438,12 @@ if (!doNotTrack) {
       <i class="fab fa-twitter"></i>
     </a>
   </li>
+	
+ <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="Mastodon" aria-label="Mastodon">
+    <a class="text-white" target="_blank" href="https://fosstodon.org/@regolith">
+      <i class="fab fa-mastodon"></i>
+    </a>
+  </li>
   
   <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="Github Issues" aria-label="Github Issues">
     <a class="text-white" target="_blank" href="https://github.com/regolith-linux/regolith-desktop/issues">


### PR DESCRIPTION
Link to mastodon account, between Twitter and Github. (I did not test it, only checked that Mastodon was available in font-awesome and added the blurb for the icon)